### PR TITLE
Improve Starfield cleanup

### DIFF
--- a/src/components/home/Starfield.astro
+++ b/src/components/home/Starfield.astro
@@ -10,124 +10,124 @@
     const isDarkMode =
       root.getAttribute("data-theme") === "dark" || !root.getAttribute("data-theme");
 
-  const COUNT = 300;
-  const SPEED = Math.random() * 0.1 + 0.25;
+    const COUNT = 300;
+    const SPEED = Math.random() * 0.1 + 0.25;
 
-  class Star {
-    x: number;
-    y: number;
-    z: number;
-    xPrev: number;
-    yPrev: number;
+    class Star {
+      x: number;
+      y: number;
+      z: number;
+      xPrev: number;
+      yPrev: number;
 
-    constructor(x = 0, y = 0, z = 0) {
-      this.x = x;
-      this.y = y;
-      this.z = z;
-      this.xPrev = x;
-      this.yPrev = y;
-    }
+      constructor(x = 0, y = 0, z = 0) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.xPrev = x;
+        this.yPrev = y;
+      }
 
-    update(width: number, height: number, speed: number) {
-      this.xPrev = this.x;
-      this.yPrev = this.y;
-      this.z += speed * 0.0675;
-      this.x += this.x * (speed * 0.0225) * this.z;
-      this.y += this.y * (speed * 0.0225) * this.z;
-      if (
-        this.x > width / 2 ||
-        this.x < -width / 2 ||
-        this.y > height / 2 ||
-        this.y < -height / 2
-      ) {
-        this.x = Math.random() * width - width / 2;
-        this.y = Math.random() * height - height / 2;
+      update(width: number, height: number, speed: number) {
         this.xPrev = this.x;
         this.yPrev = this.y;
-        this.z = 0;
+        this.z += speed * 0.0675;
+        this.x += this.x * (speed * 0.0225) * this.z;
+        this.y += this.y * (speed * 0.0225) * this.z;
+        if (
+          this.x > width / 2 ||
+          this.x < -width / 2 ||
+          this.y > height / 2 ||
+          this.y < -height / 2
+        ) {
+          this.x = Math.random() * width - width / 2;
+          this.y = Math.random() * height - height / 2;
+          this.xPrev = this.x;
+          this.yPrev = this.y;
+          this.z = 0;
+        }
+      }
+
+      draw(ctx: CanvasRenderingContext2D) {
+        ctx.lineWidth = this.z;
+        ctx.beginPath();
+        ctx.moveTo(this.x, this.y);
+        ctx.lineTo(this.xPrev, this.yPrev);
+        ctx.stroke();
       }
     }
 
-    draw(ctx: CanvasRenderingContext2D) {
-      ctx.lineWidth = this.z;
-      ctx.beginPath();
-      ctx.moveTo(this.x, this.y);
-      ctx.lineTo(this.xPrev, this.yPrev);
-      ctx.stroke();
-    }
-  }
+    const stars = Array.from({ length: COUNT }, () => new Star(0, 0, 0));
+    let rafId = 0;
 
-  const stars = Array.from({ length: COUNT }, () => new Star(0, 0, 0));
-  let rafId = 0;
+    const canvas = document.querySelector("#starfield-canvas") as HTMLCanvasElement;
+    invariant(canvas, "canvas should not be null");
+    const ctx = canvas.getContext("2d");
 
-  const canvas = document.querySelector("#starfield-canvas") as HTMLCanvasElement;
-  invariant(canvas, "canvas should not be null");
-  const ctx = canvas.getContext("2d");
+    const container = document.querySelector("#starfield") as HTMLElement;
+    invariant(container, "container should not be null");
+    const resizeObserver = new ResizeObserver(setup);
+    const themeChangeHandler = (event: Event) => {
+      const customEvent = event as CustomEvent;
+      if (customEvent.detail) {
+        const newTheme = customEvent.detail.theme;
+        const isDarkMode = newTheme === "dark";
+        const updatedFillStyleColor = isDarkMode
+          ? "rgba(17,24,39, 0.6)"
+          : "rgba(249, 250, 251, 0.6)";
+        const updatedStrokeStyleColor = isDarkMode ? "rgba(249, 250, 251, 1)" : "rgba(17,24,39, 1)";
 
-  const container = document.querySelector("#starfield") as HTMLElement;
-  invariant(container, "container should not be null");
-  const resizeObserver = new ResizeObserver(setup);
-  const themeChangeHandler = (event: Event) => {
-    const customEvent = event as CustomEvent;
-    if (customEvent.detail) {
-      const newTheme = customEvent.detail.theme;
-      const isDarkMode = newTheme === "dark";
-      const updatedFillStyleColor = isDarkMode
-        ? "rgba(17,24,39, 0.6)"
-        : "rgba(249, 250, 251, 0.6)";
-      const updatedStrokeStyleColor = isDarkMode ? "rgba(249, 250, 251, 1)" : "rgba(17,24,39, 1)";
+        ctx.fillStyle = updatedFillStyleColor;
+        ctx.strokeStyle = updatedStrokeStyleColor;
+      }
+    };
+    resizeObserver.observe(container);
+    document.addEventListener("theme-change", themeChangeHandler);
+    setup();
 
-      ctx.fillStyle = updatedFillStyleColor;
-      ctx.strokeStyle = updatedStrokeStyleColor;
-    }
-  };
-  resizeObserver.observe(container);
-  document.addEventListener("theme-change", themeChangeHandler);
-  setup();
+    function setup() {
+      invariant(ctx, "canvas context should not be null");
+      rafId > 0 && cancelAnimationFrame(rafId);
 
-  function setup() {
-    invariant(ctx, "canvas context should not be null");
-    rafId > 0 && cancelAnimationFrame(rafId);
+      const { clientWidth: width, clientHeight: height } = container;
+      const dpr = window.devicePixelRatio || 1;
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      ctx.scale(dpr, dpr);
 
-    const { clientWidth: width, clientHeight: height } = container;
-    const dpr = window.devicePixelRatio || 1;
-    canvas.width = width * dpr;
-    canvas.height = height * dpr;
-    canvas.style.width = `${width}px`;
-    canvas.style.height = `${height}px`;
-    ctx.scale(dpr, dpr);
+      for (const star of stars) {
+        star.x = Math.random() * width - width / 2;
+        star.y = Math.random() * height - height / 2;
+        star.z = 0;
+      }
 
-    for (const star of stars) {
-      star.x = Math.random() * width - width / 2;
-      star.y = Math.random() * height - height / 2;
-      star.z = 0;
-    }
+      ctx.translate(width / 2, height / 2);
+      const fillStyleColor = isDarkMode ? "rgba(17, 24, 39, 0.6)" : "rgba(249, 250, 251, 0.6)";
+      const strokeStyleColor = isDarkMode ? "rgba(249, 250, 251, 1)" : "rgba(17,24,39, 1)";
 
-    ctx.translate(width / 2, height / 2);
-    const fillStyleColor = isDarkMode ? "rgba(17, 24, 39, 0.6)" : "rgba(249, 250, 251, 0.6)";
-    const strokeStyleColor = isDarkMode ? "rgba(249, 250, 251, 1)" : "rgba(17,24,39, 1)";
+      ctx.fillStyle = fillStyleColor;
+      ctx.strokeStyle = strokeStyleColor;
 
-    ctx.fillStyle = fillStyleColor;
-    ctx.strokeStyle = strokeStyleColor;
+      // themeChangeHandler registered outside of setup
 
-    // themeChangeHandler registered outside of setup
-
-    rafId = requestAnimationFrame(frame);
-  }
-
-  function frame() {
-    invariant(ctx, "canvas context should not be null");
-    const { clientWidth: width, clientHeight: height } = container;
-
-    for (const star of stars) {
-      star.update(width, height, SPEED);
-      star.draw(ctx);
+      rafId = requestAnimationFrame(frame);
     }
 
-    ctx.fillRect(-width / 2, -height / 2, width, height);
-    rafId = requestAnimationFrame(frame);
-  }
+    function frame() {
+      invariant(ctx, "canvas context should not be null");
+      const { clientWidth: width, clientHeight: height } = container;
 
+      for (const star of stars) {
+        star.update(width, height, SPEED);
+        star.draw(ctx);
+      }
+
+      ctx.fillRect(-width / 2, -height / 2, width, height);
+      rafId = requestAnimationFrame(frame);
+    }
+    //  ResizeObserver and theme change handler cleanup
     const cleanup = () => {
       resizeObserver.disconnect();
       document.removeEventListener("theme-change", themeChangeHandler);

--- a/src/components/home/Starfield.astro
+++ b/src/components/home/Starfield.astro
@@ -5,8 +5,10 @@
 <script>
   import invariant from "tiny-invariant";
 
-  const root = document.documentElement;
-  const isDarkMode = root.getAttribute("data-theme") === "dark" || !root.getAttribute("data-theme");
+  const cleanup = (() => {
+    const root = document.documentElement;
+    const isDarkMode =
+      root.getAttribute("data-theme") === "dark" || !root.getAttribute("data-theme");
 
   const COUNT = 300;
   const SPEED = Math.random() * 0.1 + 0.25;
@@ -65,7 +67,23 @@
   const container = document.querySelector("#starfield") as HTMLElement;
   invariant(container, "container should not be null");
   const resizeObserver = new ResizeObserver(setup);
+  const themeChangeHandler = (event: Event) => {
+    const customEvent = event as CustomEvent;
+    if (customEvent.detail) {
+      const newTheme = customEvent.detail.theme;
+      const isDarkMode = newTheme === "dark";
+      const updatedFillStyleColor = isDarkMode
+        ? "rgba(17,24,39, 0.6)"
+        : "rgba(249, 250, 251, 0.6)";
+      const updatedStrokeStyleColor = isDarkMode ? "rgba(249, 250, 251, 1)" : "rgba(17,24,39, 1)";
+
+      ctx.fillStyle = updatedFillStyleColor;
+      ctx.strokeStyle = updatedStrokeStyleColor;
+    }
+  };
   resizeObserver.observe(container);
+  document.addEventListener("theme-change", themeChangeHandler);
+  setup();
 
   function setup() {
     invariant(ctx, "canvas context should not be null");
@@ -92,20 +110,7 @@
     ctx.fillStyle = fillStyleColor;
     ctx.strokeStyle = strokeStyleColor;
 
-    document.addEventListener("theme-change", (event: Event) => {
-      const customEvent = event as CustomEvent;
-      if (customEvent.detail) {
-        const newTheme = customEvent.detail.theme;
-        const isDarkMode = newTheme === "dark";
-        const updatedFillStyleColor = isDarkMode
-          ? "rgba(17,24,39, 0.6)"
-          : "rgba(249, 250, 251, 0.6)";
-        const updatedStrokeStyleColor = isDarkMode ? "rgba(249, 250, 251, 1)" : "rgba(17,24,39, 1)";
-
-        ctx.fillStyle = updatedFillStyleColor;
-        ctx.strokeStyle = updatedStrokeStyleColor;
-      }
-    });
+    // themeChangeHandler registered outside of setup
 
     rafId = requestAnimationFrame(frame);
   }
@@ -121,5 +126,18 @@
 
     ctx.fillRect(-width / 2, -height / 2, width, height);
     rafId = requestAnimationFrame(frame);
+  }
+
+    const cleanup = () => {
+      resizeObserver.disconnect();
+      document.removeEventListener("theme-change", themeChangeHandler);
+      rafId > 0 && cancelAnimationFrame(rafId);
+    };
+
+    return cleanup;
+  })();
+
+  if (import.meta.hot) {
+    import.meta.hot.dispose(cleanup);
   }
 </script>

--- a/src/components/home/Starfield.astro
+++ b/src/components/home/Starfield.astro
@@ -62,7 +62,7 @@
 
     const canvas = document.querySelector("#starfield-canvas") as HTMLCanvasElement;
     invariant(canvas, "canvas should not be null");
-    const ctx = canvas.getContext("2d");
+    const ctx: CanvasRenderingContext2D | null = canvas.getContext("2d");
 
     const container = document.querySelector("#starfield") as HTMLElement;
     invariant(container, "container should not be null");
@@ -95,7 +95,7 @@
       canvas.height = height * dpr;
       canvas.style.width = `${width}px`;
       canvas.style.height = `${height}px`;
-      ctx.scale(dpr, dpr);
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
 
       for (const star of stars) {
         star.x = Math.random() * width - width / 2;
@@ -128,13 +128,13 @@
       rafId = requestAnimationFrame(frame);
     }
     //  ResizeObserver and theme change handler cleanup
-    const cleanup = () => {
+    const dispose = () => {
       resizeObserver.disconnect();
       document.removeEventListener("theme-change", themeChangeHandler);
       rafId > 0 && cancelAnimationFrame(rafId);
     };
 
-    return cleanup;
+    return dispose;
   })();
 
   if (import.meta.hot) {


### PR DESCRIPTION
## Summary
- store reference to theme-change listener in Starfield script
- expose cleanup routine that disconnects the observer, cancels raf and removes listener

## Testing
- `pnpm run check` *(fails: Property 'content' does not exist on type 'Element')*

------
https://chatgpt.com/codex/tasks/task_e_683feddb380c832488512634d31161af

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved theme change handling for the starfield background to ensure smoother and more reliable updates when switching themes.
  - Enhanced resource management for better performance and stability during hot module replacement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->